### PR TITLE
Click when clicable

### DIFF
--- a/MK6.AutomatedTesting.UI/Components/Button.cs
+++ b/MK6.AutomatedTesting.UI/Components/Button.cs
@@ -1,16 +1,39 @@
-﻿using OpenQA.Selenium;
+﻿using System;
+using OpenQA.Selenium;
+using OpenQA.Selenium.Support.UI;
 
 namespace MK6.AutomatedTesting.UI.Components
 {
     public class Button : PageElement
     {
+        private readonly IWebDriver _browser;
+
         public Button(IWebDriver browser, By findBy)
             : base(browser, findBy)
-        { }
+        {
+            _browser = browser;
+        }
 
         public void Click()
         {
-            this.Element.Click();
+            Click(TimeSpan.FromSeconds(5));
+        }
+
+        public void Click(TimeSpan timeout)
+        {
+            var wait = new WebDriverWait(_browser, timeout);
+            wait.Until(driver =>
+            {
+                try
+                {
+                    Element.Click();
+                    return true;
+                }
+                catch
+                {
+                    return false;
+                }
+            });
         }
     }
 }


### PR DESCRIPTION
By default, wait for up to 5 seconds for the button to be clickable, in order to avoid "Element not clickable" exception.
