### PR TITLE
Allow PhantomJS to take additional command argument

### DIFF
--- a/MK6.AutomatedTesting.UI/Configuration/DriverConfigurationSection.cs
+++ b/MK6.AutomatedTesting.UI/Configuration/DriverConfigurationSection.cs
@@ -14,6 +14,8 @@ namespace MK6.AutomatedTesting.UI.Configuration
 
         private const string RemoteBrowserVersionKey = "remoteBrowserVersion";
 
+        private const string CommandArgumentKey = "commandArgument";
+
         [ConfigurationProperty(BrowserKey, IsRequired = true)]
         public string Browser
         {
@@ -37,6 +39,19 @@ namespace MK6.AutomatedTesting.UI.Configuration
             set
             {
                 this[ServerSourceKey] = value;
+            }
+        }
+
+        [ConfigurationProperty(CommandArgumentKey, IsRequired = false, DefaultValue = "")]
+        public string CommandArgument
+        {
+            get
+            {
+                return this[CommandArgumentKey].ToString();
+            }
+            set
+            {
+                this[CommandArgumentKey] = value;
             }
         }
 

--- a/MK6.AutomatedTesting.UI/DriverFactory.cs
+++ b/MK6.AutomatedTesting.UI/DriverFactory.cs
@@ -34,9 +34,7 @@ namespace MK6.AutomatedTesting.UI
                         });
                 case "PhantomJS":
                     CopyPhantomJSServerToLocalDirectory(configSection.ServerSource);
-                    var browser = new PhantomJSDriver();
-                    ApplyPhantomJSHack(browser);
-                    return browser;
+                    return BuildPhantomJsBrowser(configSection);
                 case "Remote":
                     return new RemoteWebDriver(
                         new Uri(configSection.RemoteUrl),
@@ -47,6 +45,18 @@ namespace MK6.AutomatedTesting.UI
                             "Unable to create a driver of type {0}",
                             configSection.Browser));
             }
+        }
+
+        private static IWebDriver BuildPhantomJsBrowser(DriverConfigurationSection configSection)
+        {
+            PhantomJSDriverService service = PhantomJSDriverService.CreateDefaultService();
+            if (!string.IsNullOrEmpty(configSection.CommandArgument))
+            {
+                service.AddArgument(configSection.CommandArgument);
+            }
+            var browser = new PhantomJSDriver(service);
+            ApplyPhantomJSHack(browser);
+            return browser;
         }
 
         public static DesiredCapabilities BuildRemoteCapabilities(DriverConfigurationSection configSection)


### PR DESCRIPTION
We want to disable the logging from webdriver in PhantomJS. Changed to allow additional command argument to be passed in. 
